### PR TITLE
Pin stripe-node version for TypeScript.

### DIFF
--- a/server/typescript/package.json
+++ b/server/typescript/package.json
@@ -16,10 +16,9 @@
     "body-parser": "^1.19.0",
     "dotenv": "latest",
     "express": "^4.17.1",
-    "stripe": "^8.0.1"
+    "stripe": "8.24.1"
   },
   "devDependencies": {
-    "@types/dotenv": "^8.2.0",
     "@types/express": "^4.17.2",
     "@types/node": "^13.1.2",
     "tslint": "^5.20.1",


### PR DESCRIPTION
Specifically pin the stripe-node version to the last version that ships with `2019-12-03` types: https://github.com/stripe/stripe-node/blob/master/CHANGELOG.md#8241---2020-03-02