### PR TITLE
Add validation on available networks for Kotlin

### DIFF
--- a/client/android-kotlin/app/build.gradle
+++ b/client/android-kotlin/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     buildFeatures {
         viewBinding = true
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         applicationId "com.example.app"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -43,7 +43,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
 
     // Stripe Android SDK
-    implementation 'com.stripe:stripe-android:20.3.0'
+    implementation 'com.stripe:stripe-android:20.13.0'
 
     // OkHttp & GSON
     implementation 'com.squareup.okhttp3:okhttp:4.2.0'

--- a/client/android-kotlin/build.gradle
+++ b/client/android-kotlin/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.5.21'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         jcenter()

--- a/client/ios-objc/CardBrandChoice/CardBrandChoiceViewController.m
+++ b/client/ios-objc/CardBrandChoice/CardBrandChoiceViewController.m
@@ -203,12 +203,12 @@ NSString *const BackendUrl = @"http://127.0.0.1:4242/";
     STPPaymentMethodParams *paymentMethodParams = [STPPaymentMethodParams paramsWithCard:cardParams billingDetails:billingDetails metadata:nil];
     STPPaymentIntentParams *paymentIntentParams = [[STPPaymentIntentParams alloc] initWithClientSecret:self.paymentIntentClientSecret];
 
-    [STPAPIClient.sharedClient createPaymentMethodWithParams:paymentMethodParams completion:^(STPPaymentMethod *paymentMethod, NSError *handleActionError) {
+    [[STPAPIClient sharedClient] createPaymentMethodWithParams:paymentMethodParams completion:^(STPPaymentMethod *paymentMethod, NSError *handleActionError) {
         if (paymentMethod) {
             NSArray *availableNetworks = paymentMethod.card.networks.available;
             NSString *network = [self brandMap][self.dropdownTextField.text];
             if ([availableNetworks containsObject:network]) {
-                STPConfirmCardOptions *cardOptions =  [[STPConfirmCardOptions alloc] init];
+                STPConfirmCardOptions *cardOptions = [[STPConfirmCardOptions alloc] init];
                 STPConfirmPaymentMethodOptions *paymentMethodOptions = [[STPConfirmPaymentMethodOptions alloc] init];
                 cardOptions.network = network;
                 paymentMethodOptions.cardOptions = cardOptions;

--- a/client/ios-swift/CardBrandChoice/CardBrandChoiceViewController.swift
+++ b/client/ios-swift/CardBrandChoice/CardBrandChoiceViewController.swift
@@ -194,11 +194,11 @@ class CardBrandChoiceViewController: UIViewController {
         STPAPIClient.shared.createPaymentMethod(with: paymentMethodParams) { paymentMethod, error in
             if let paymentMethod = paymentMethod {
                 if let availableNetworks = paymentMethod.card?.networks?.available, let network = self.cardBrand, availableNetworks.contains(network) {
-                    let confirmCardOptions = STPConfirmCardOptions()
-                    let confirmPaymentMethodOptions = STPConfirmPaymentMethodOptions()
-                    confirmCardOptions.network = network
-                    confirmPaymentMethodOptions.cardOptions = confirmCardOptions
-                    paymentIntentParams.paymentMethodOptions = confirmPaymentMethodOptions
+                    let cardOptions = STPConfirmCardOptions()
+                    let paymentMethodOptions = STPConfirmPaymentMethodOptions()
+                    cardOptions.network = network
+                    paymentMethodOptions.cardOptions = cardOptions
+                    paymentIntentParams.paymentMethodOptions = paymentMethodOptions
                 }
                 paymentIntentParams.paymentMethodId = paymentMethod.stripeId
                 self.confirmPayment(sender: sender, paymentIntentParams: paymentIntentParams)


### PR DESCRIPTION
This adds validation on the available networks of the card for the Kotlin sample; now, instead of failing the PaymentIntent confirmation when a non-sensical brand is selected, it'll instead ignore the user input. It also more easily allows other approaches to handling this scenario.

In order to do that, I had to bump some plugin versions to support the most recent Stripe SDK version, since the available networks was an internal property in previous versions. See [this PR](https://github.com/stripe/stripe-android/pull/5552) for the change.

I'm also renaming some variables to be more in line with the [Stripe Docs on Card Brand Choice](https://stripe.com/docs/card-brand-choice).